### PR TITLE
Disable monitoring in prod by default

### DIFF
--- a/.github/workflows/instance-deploy-prod.yml
+++ b/.github/workflows/instance-deploy-prod.yml
@@ -2,8 +2,27 @@ name: "Instance - deploy prod"
 on:
   push:
     branches: [main]
+  workflow_dispach:
+    inputs:
+      monitoring_enabled:
+        description: Deploy jaeger instance for monitoring (£20/month)
+        type: boolean
+        required: true
+        default: false
 
 jobs:
+  variables:
+    id: variables
+    run: |
+      if [[ "${{ inputs.monitoring_enabled}}" == "" ]]
+      then
+        echo "monitoring_enabled=false"
+        echo "monitoring_enabled=false" >> $GITHUB_OUTPUT
+      else
+        echo "monitoring_enabled=${{ inputs.monitoring_enabled}}"
+        echo "monitoring_enabled=${{ inputs.monitoring_enabled}}" >> $GITHUB_OUTPUT
+      fi
+
   build-api:
     uses: benchiverton/OnlineStore/.github/workflows/workflow-build-test-publish-dotnet.yml@main
     with:
@@ -58,6 +77,7 @@ jobs:
           TF_VAR_environment: prod
           TF_VAR_acr_username: ${{ secrets.ACR_USERNAME }}
           TF_VAR_acr_password: ${{ secrets.ACR_TOKEN }}
+          TF_VAR_monitoring_enabled: ${{ steps.variables.outputs.monitoring_enabled }}
       - name: Terraform Apply
         id: apply
         run: terraform -chdir=instance apply -auto-approve
@@ -66,6 +86,7 @@ jobs:
           TF_VAR_environment: prod
           TF_VAR_acr_username: ${{ secrets.ACR_USERNAME }}
           TF_VAR_acr_password: ${{ secrets.ACR_TOKEN }}
+          TF_VAR_monitoring_enabled: ${{ steps.variables.outputs.monitoring_enabled }}
       - name: Save terraform outputs
         shell: bash
         run: |

--- a/.github/workflows/instance-deploy-test.yml
+++ b/.github/workflows/instance-deploy-test.yml
@@ -58,6 +58,7 @@ jobs:
           TF_VAR_environment: ${{ github.head_ref }}
           TF_VAR_acr_username: ${{ secrets.ACR_USERNAME }}
           TF_VAR_acr_password: ${{ secrets.ACR_TOKEN }}
+          TF_VAR_monitoring_enabled: true # enabled for testing
       - name: Terraform Apply
         id: apply
         run: terraform -chdir=instance apply -auto-approve
@@ -66,6 +67,7 @@ jobs:
           TF_VAR_environment: ${{ github.head_ref }}
           TF_VAR_acr_username: ${{ secrets.ACR_USERNAME }}
           TF_VAR_acr_password: ${{ secrets.ACR_TOKEN }}
+          TF_VAR_monitoring_enabled: true # enabled for testing
       - name: Save terraform outputs
         shell: bash
         run: |

--- a/terraform/instance/container_instances.tf
+++ b/terraform/instance/container_instances.tf
@@ -1,4 +1,5 @@
 resource "azurerm_container_group" "monitoring" {
+  count               = var.monitoring_enabled ? 1 : 0
   name                = "${var.name}-containergroup-monitoring"
   resource_group_name = azurerm_resource_group.instance.name
   location            = azurerm_resource_group.instance.location

--- a/terraform/instance/variables.tf
+++ b/terraform/instance/variables.tf
@@ -39,3 +39,9 @@ variable "acr_password" {
   description = "The password to log in to ACR"
   sensitive   = true
 }
+
+variable "monitoring_enabled" {
+  type        = bool
+  description = "Location to deploy the resoruce group"
+  default     = true
+}


### PR DESCRIPTION
Azure container instances are racking up ~£20/month, and as this is a hobby project I don't want it deployed to prod by default